### PR TITLE
Fix typo in Google Chromecast documentation

### DIFF
--- a/_i18n/en/documentation/playback/chromecast.md
+++ b/_i18n/en/documentation/playback/chromecast.md
@@ -21,4 +21,4 @@ Make sure that you are in the same WiFi network as your Chromecast.
 
 ### Did you download AntennaPod from **F-Droid**?
 
-Unforntunately, Google Chromecast support is not available in the F-Droid version because Chromecast is not open-source.
+Unfortunately, Google Chromecast support is not available in the F-Droid version because Chromecast is not open-source.


### PR DESCRIPTION
Spotted a typo while translating. This PR fixes it.